### PR TITLE
ci(secret-scanner): drop duplicate --fail from trufflehog extra_args

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -20,7 +20,9 @@ jobs:
       - name: TruffleHog Secret Scan
         uses: trufflesecurity/trufflehog@6c05c4a00b91aa542267d8e32a8254774799d68d # v3
         with:
-          extra_args: --only-verified --fail
+          # The v3 action injects --fail automatically on pull_request events.
+          # Passing --fail here triggers "flag 'fail' cannot be repeated".
+          extra_args: --only-verified
 
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Propagates the rsr-template-repo#37 fix: trufflehog v3 auto-injects `--fail` on `pull_request` events, so passing it again as `extra_args` produced `flag 'fail' cannot be repeated` and broke every secret-scanner run. Dropping the duplicate restores green secret-scanner CI on this repo.