### PR TITLE
fix(ci): hypatia-scan.yml -- --exit-zero + GITHUB_TOKEN (hyperpolymath/hypatia#213)

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -49,11 +49,14 @@ jobs:
 
       - name: Run Hypatia scan
         id: scan
+        env:
+          # Suppress the Dependabot "GITHUB_TOKEN not set" warning.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Scanning repository: ${{ github.repository }}"
 
           # Run scanner
-          HYPATIA_FORMAT=json "$HOME/hypatia/hypatia-cli.sh" scan . > hypatia-findings.json
+          HYPATIA_FORMAT=json "$HOME/hypatia/hypatia-cli.sh" scan . --exit-zero > hypatia-findings.json
 
           # Count findings
           FINDING_COUNT=$(jq '. | length' hypatia-findings.json 2>/dev/null || echo 0)
@@ -75,7 +78,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: hypatia-findings
           path: hypatia-findings.json


### PR DESCRIPTION
Mirrors hyperpolymath/hypatia#228 in this consumer repo.

## What was actually broken in `Hypatia Security Scan`

The scanner halts with `System.halt(1)` whenever findings exist at or above the severity threshold (`lib/hypatia/cli.ex:158-160` pre-#228). Under GitHub Actions' default `set -e`, that exit-1 short-circuits the workflow step before `jq` aggregation, `actions/upload-artifact`, the PR comment, AND the explicit "Check for critical or high-severity issues" step.

The previous `actions/upload-artifact` SHA-bump sweep across the estate (41 PRs) was based on a wrong diagnosis -- the failing runs were not at action-resolve time. See hyperpolymath/hypatia#213 for the full root-cause writeup.

## Changes in this PR

- **Pass `GITHUB_TOKEN`** to the scan step env so the Dependabot rule can query alerts (and stops emitting `Warning: Dependabot alerts unavailable: GITHUB_TOKEN not set`).
- **Append `--exit-zero`** to the `hypatia-cli.sh scan .` invocation so findings-at-severity no longer short-circuits the step. The downstream "Check for critical or high-severity issues" step (already in this workflow) remains the explicit gate.
- **Pin `actions/upload-artifact` to v4.6.2** (`ea165f8d65b6e75b540449e92b4886f43607fa02`) to match the estate-wide pin.

## Notes

- `--exit-zero` was added in hyperpolymath/hypatia#228 and is silently ignored by pre-#228 versions of the scanner (OptionParser strict mode places unknown flags in `invalid` and the CLI discards that), so this PR is safe to merge in either order relative to #228.
- This change does not affect non-CI usage of the scanner; the default `exit 1` on findings is unchanged for shell / pre-commit users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
