### PR TITLE
fix(orchestrator): add switch_project/clear_history/recent_history delegators (restore bin build)

### DIFF
--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -18,7 +18,7 @@ use crate::{
     context::ContextManager,
     expert::ExpertSystem,
     router::{Router, RouterConfig},
-    types::{Query, Response, ResponseMetadata, RoutingDecision},
+    types::{ConversationTurn, Query, Response, ResponseMetadata, RoutingDecision},
 };
 
 /// Orchestrator: Coordinates the full AI pipeline.
@@ -81,6 +81,21 @@ impl Orchestrator {
         self.context.add_turn(query, response.clone());
 
         Ok(response)
+    }
+
+    /// Set the active project on the underlying ContextManager.
+    pub fn switch_project(&mut self, project: impl Into<String>) {
+        self.context.switch_project(project);
+    }
+
+    /// Drop the active project's conversation history.
+    pub fn clear_history(&mut self) {
+        self.context.clear_history();
+    }
+
+    /// Borrow the N most recent turns from the active project's history.
+    pub fn recent_history(&self, n: usize) -> Vec<ConversationTurn> {
+        self.context.recent_history(n)
     }
 }
 


### PR DESCRIPTION
## Summary

\`src/main.rs\` calls three Orchestrator methods (\`switch_project\`, \`clear_history\`, \`recent_history\`) that don't exist on the type, so \`cargo check --bin mobile-ai\` fails with 4 E0599 errors. All three methods already exist on the inner \`ContextManager\`, so the fix is three pure-delegation forwarders.

## Changes (16 lines)

- \`src/orchestrator.rs\`:
  - Import \`ConversationTurn\` from \`crate::types\` (already declared there) for \`recent_history\`'s return type
  - Add \`Orchestrator::switch_project(&mut self, impl Into<String>)\` → delegates to \`self.context.switch_project\`
  - Add \`Orchestrator::clear_history(&mut self)\` → delegates to \`self.context.clear_history\`
  - Add \`Orchestrator::recent_history(&self, usize) -> Vec<ConversationTurn>\` → delegates to \`self.context.recent_history\`

## Verification

- \`cargo check --workspace\` — green
- \`cargo test --lib\` — 39/41 pass; the 2 failing tests (\`snn::tests::test_lif_neuron_reset\` and \`snn::tests::test_spiking_network_reset\`) fail on main HEAD and are unrelated to this fix (SNN spike-reset behaviour, out of scope here).

## Context

Surfaced 2026-05-27 by PR #41 (Cargo CVE phantom-strip pilot). #41's body noted the four pre-existing E0599 errors as out-of-scope for the CVE work and worth fixing separately. This is that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)