### PR TITLE
fix: add lib accessors so examples compile

### DIFF
--- a/src/mlp.rs
+++ b/src/mlp.rs
@@ -146,6 +146,24 @@ impl MLP {
         // Phase 2 implementation
     }
 
+    /// Number of input features the network expects.
+    pub fn input_size(&self) -> usize {
+        self.input_size
+    }
+
+    /// Number of output classes the network produces.
+    pub fn output_size(&self) -> usize {
+        self.output_size
+    }
+
+    /// Run one training step: compute loss and gradients via `backward`,
+    /// apply them with `update`, and return the loss for this step.
+    pub fn train_step(&mut self, input: &[f32], target: &[f32], learning_rate: f32) -> f32 {
+        let (loss, gradients) = self.backward(input, target);
+        self.update(&gradients, learning_rate);
+        loss
+    }
+
     /// Argmax: Return the index of the maximum value.
     pub fn argmax(values: &[f32]) -> usize {
         values

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -88,6 +88,11 @@ impl Orchestrator {
         self.context.switch_project(project);
     }
 
+    /// Borrow the active project name, if one is set.
+    pub fn current_project(&self) -> Option<&str> {
+        self.context.current_project()
+    }
+
     /// Drop the active project's conversation history.
     pub fn clear_history(&mut self) {
         self.context.clear_history();


### PR DESCRIPTION
The library compiles clean; the two examples `basic_usage.rs` and `mlp_router.rs` called methods that don't exist on the public API (8x E0599 for stale API names).

Adds thin 1:1 accessor / convenience wrappers to the lib (preferred approach):
- `Orchestrator::current_project()` — delegates to the context manager
- `MLP::input_size()` / `MLP::output_size()` — getters for private fields
- `MLP::train_step(input, target, lr)` — runs `backward` + `update`, returns the step loss

`cargo check --examples` is now clean (0 errors). `reservoir_demo.rs` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)